### PR TITLE
trim devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,22 +21,8 @@ components:
       dockerfile:
         uri: Dockerfile
         buildContext: .
-        rootRequired: false
-  - name: outerloop-deploy
-    kubernetes:
-      uri: outerloop-deploy.yaml
+        rootRequired: false 
 commands:
   - id: build-image
     apply:
-      component: outerloop-build
-  - id: deployk8s
-    apply:
-      component: outerloop-deploy
-  - id: deploy
-    composite:
-      commands:
-        - build-image
-        - deployk8s
-      group:
-        kind: deploy
-        isDefault: true
+      component: outerloop-build 


### PR DESCRIPTION
Remove references to the `outerloop-deploy.yaml` in the devfile as it is not present in the repo

Invalid devfiles are now allowed in to HAS / Stone soup